### PR TITLE
Upgrade package to work with dbt-utils >v1.0.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,3 +19,6 @@ models:
       +tags: sources
     tests:
       +tags: tests
+
+vars:
+  surrogate_key_treat_nulls_as_empty_strings: true 

--- a/models/sources/raw_source_freshness.sql
+++ b/models/sources/raw_source_freshness.sql
@@ -18,7 +18,7 @@ with dedup_logs as
 flatten_records as
 (
     select
-        {{ dbt_utils.surrogate_key(['payload_id', 'payload_timestamp_utc', 'results.value:unique_id']) }} as id,
+        {{ dbt_utils.generate_surrogate_key(['payload_id', 'payload_timestamp_utc', 'results.value:unique_id']) }} as id,
         payload_id,
         payload_timestamp_utc,
         results.value:unique_id::string as unique_id,

--- a/models/tests/raw_tests.sql
+++ b/models/tests/raw_tests.sql
@@ -18,7 +18,7 @@ with dedup_logs as
 flatten_records as
 (
     select
-        {{ dbt_utils.surrogate_key(['payload_id', 'payload_timestamp_utc', 'results.value:unique_id']) }} as id,
+        {{ dbt_utils.generate_surrogate_key(['payload_id', 'payload_timestamp_utc', 'results.value:unique_id']) }} as id,
         payload_id,
         payload_timestamp_utc,
         results.value:unique_id::string as unique_id,

--- a/models/tests/raw_tests_manifest.sql
+++ b/models/tests/raw_tests_manifest.sql
@@ -21,7 +21,7 @@ flatten_records as
         ,tests_content.key
         ,case
             when tests_content.key = 'tags' 
-                then coalesce(replace(replace(replace(regexp_substr(replace(replace(tests_content.value,' '),'\'','"'), '(dq:)[^,]+(",)|(dq:)[^,]+("])'),'dq:'),'",'),'"]'),'unkonwn')
+                then coalesce(replace(replace(replace(regexp_substr(replace(replace(tests_content.value,' '),'\'','"'), '(dq:)[^,]+(",)|(dq:)[^,]+("])'),'dq:'),'",'),'"]'),'unknown')
             when tests_content.key = 'column_name' 
                 then coalesce(tests_content.value, 'n/a')
             else tests_content.value

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.2
+    version: [">=1.0.0" , "<2.0.0"]


### PR DESCRIPTION
As said in this issue https://github.com/Divergent-Insights/dbt-dataquality/issues/13, this PR is created to fix the dbt-utils dependency issues for dbt-utils version >v1.0.0. This will allow everyone who uses the latest version of dbt-utils to use your great dbt package. 

Some background on the changes made to the dbt_utils.surrogate_key macro in version 1.0.0: https://docs.getdbt.com/guides/migration/versions/upgrading-to-dbt-utils-v1.0#changes-to-surrogate_key

Let me know if there's anything more I can do to help!